### PR TITLE
Add error checking

### DIFF
--- a/run.py
+++ b/run.py
@@ -93,7 +93,7 @@ def do_single_test(test, rotation):
     gtp += "heatmap %s\ngenmove %s" % (rotation, test['move'])
     listgtp = gtp.split('\n')
     gtp = "(echo " + " && echo ".join(listgtp) + ")"
-    lines = subprocess.check_output("%s | %s" % (gtp, command), stderr=subprocess.STDOUT, shell=True, encoding='utf8').split("\n")
+    lines = subprocess.check_output("%s | %s" % (gtp, command), stderr=subprocess.STDOUT, shell=True).decode('utf-8').split("\n")
     debug([line for line in lines if re.search('Thinking at most', line)][0] + "\n")
     #   E1 ->     792 (V: 37.43%) (N: 31.68%) PV: E1 H5 F6 G6 F7 E13 D11 D10 E10 E9 F9 E11
     lines = [line for line in lines if re.match('^\s+[A-Z][0-9]+ +->|^[0-9]+\s+visits', line)]

--- a/run.py
+++ b/run.py
@@ -7,6 +7,7 @@ import yaml
 import argparse
 import sys
 import platform
+import os
 
 class bcolors:
     HEADER = '\033[95m'
@@ -162,6 +163,10 @@ for test in tests:
     if args.group and group not in args.group:
         continue
     my_print("%s - %s (%s)\n" % (name, group, sgf))
+
+    if not os.path.isfile(os.path.join('sgf', test['sgf'])):
+        my_print('SGF file %s not found\n' % test['sgf'])
+        continue
 
     results = []
     for i in range(0, DEFAULT_MULTI_RUNS):


### PR DESCRIPTION
SGF file `12383186-296-inelasticneutron-RoyalZero.sgf` for test `race4` is missing. There isn't error checking for missing files right now so it just fails silently. This commit adds check that SGF file exists and prints error if it's missing.

`encoding` option didn't work for me so I changed it to use `string.decode` instead.